### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=liaodongyang
 maintainer=liaodongyang
 sentence=Library for Arduino for RGBIFsensor and LED
 paragraph=
-category=sensor
+category=Sensors
 url=http://github.com/liaodongyang/p12347_library
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:

WARNING: Category 'sensor' in library p12347_library is not valid. Setting to 'Uncategorized'

List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format